### PR TITLE
Исправлен баг

### DIFF
--- a/FirstApp/FirstApp/Views/CalcPage.xaml
+++ b/FirstApp/FirstApp/Views/CalcPage.xaml
@@ -65,7 +65,7 @@
 
 
         </Grid>
-        <Entry Text="{Binding Text}"/>
+        <Entry x:Name="CreateContainer" Text="{Binding Text}"/>
         <Button Text="Save" Clicked="BtnSave_Clicked"/>
 
 

--- a/FirstApp/FirstApp/Views/CalcPage.xaml.cs
+++ b/FirstApp/FirstApp/Views/CalcPage.xaml.cs
@@ -66,11 +66,14 @@ namespace FirstApp.Views
 
         private async void BtnSave_Clicked(object sender, EventArgs e)
         {
-            Container container = (Container)BindingContext;
-            await App.ContainersDB.SaveContainerAsync(container);
+            if (CreateContainer.Text != null)
+            {
+                Container container = (Container)BindingContext;
+                await App.ContainersDB.SaveContainerAsync(container);
 
-            var items = await ContainersDB.GetContainersAsync();
-            MyPicker.ItemsSource = (System.Collections.IList)items;
+                var items = await ContainersDB.GetContainersAsync();
+                MyPicker.ItemsSource = (System.Collections.IList)items;
+            }
         }
 
     }


### PR DESCRIPTION
При сохранении контейнера, когда ничего не введено в поле, приложение вылетало из-за попытки сохранить/получить Null.